### PR TITLE
Target Ruby 2.3 to 3.2

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -22,17 +22,17 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.7', '3.0', '3.1', '3.2']
+        ruby-version: ['2.3', '2.4', '2.5', '2.6', '2.7', '3.0', '3.1', '3.2']
 
     steps:
     - uses: actions/checkout@v3
+    - name: Remove gemfile.lock
+      run: rm Gemfile.lock
     - name: Set up Ruby
-    # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
-    # change this to (see https://github.com/ruby/setup-ruby#versioning):
-    # uses: ruby/setup-ruby@v1
-      uses: ruby/setup-ruby@ee2113536afb7f793eed4ce60e8d3b26db912da4 # v1.127.0
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby-version }}
-        bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+    - name: Bundle install
+      run: bundle install
     - name: Run tests
       run: bundle exec rspec spec

--- a/go-transit-ruby.gemspec
+++ b/go-transit-ruby.gemspec
@@ -5,7 +5,7 @@ require "go_transit_ruby/version"
 Gem::Specification.new do |s|
   s.name = "go_transit_ruby"
   s.version = GoTransit::VERSION
-  s.required_ruby_version = ">= 2.7.0"
+  s.required_ruby_version = ">= 2.3.0"
   s.summary = "Ruby Interface for the Go Transit API"
   s.author = "Justin Mazur"
   s.homepage = "https://github.com/jmazur/go_transit_ruby"


### PR DESCRIPTION
I would like to have this gem target multiple versions of ruby. Even though Ruby < 2.7 is deprecated I would like this gem to support older codebases... but for real. If you're starting a new project use a supported version of ruby