### PR TITLE
Add Helper Methods to AllLines::Line

### DIFF
--- a/lib/go_transit/resources/schedule/all_lines/line.rb
+++ b/lib/go_transit/resources/schedule/all_lines/line.rb
@@ -1,5 +1,13 @@
 module GoTransit
   class Schedule::AllLines::Line < ApiResource
     attr_accessor :name, :code, :is_bus, :is_train, :variants
+
+    def train?
+      is_train == true
+    end
+
+    def bus?
+      is_bus == true
+    end
   end
 end

--- a/readme.md
+++ b/readme.md
@@ -16,10 +16,10 @@ You can get a Go Transit API key here
 [http://api.openmetrolinx.com/OpenDataAPI/Help/Registration/en](http://api.openmetrolinx.com/OpenDataAPI/Help/Registration/en).
 
 ## Usage
-Import go-transit and set your API key.
+Import go_transit and set your API key.
 
 ```ruby
-require "go-transit"
+require "go_transit"
 GoTransit.api_key = "YOUR_API_KEY"
 ```
 
@@ -57,7 +57,7 @@ This gem exposes the Go Transit API endpoints and hydrates objects related to th
 | :-------------------------------------------------------------------------------------------------------------------------------------- | :---------------------------- |
 | `GoTransit::Schedule.journey(date: <Date>, from_stop_code: <string>, to_stop_code: <string>, start_time: <string>, max_journey: <int>)` | [Link](http://api.openmetrolinx.com/OpenDataAPI/Help/Api/en/GET-api-V1-Schedule-Journey-Date-FromStopCode-ToStopCode-StartTime-MaxJourney) |
 | `GoTransit::Schedule.line(date: <Date>, line_code: <string>, line_direction: <string>)`                                                 | [Link](http://api.openmetrolinx.com/OpenDataAPI/Help/Api/en/GET-api-V1-Schedule-Line-Date-LineCode-LineDirection) |
-| `GoTransit::Schedule::Line.all(date: <Date>)`                                                                                           | [Link](http://api.openmetrolinx.com/OpenDataAPI/Help/Api/en/GET-api-V1-Schedule-Line-All-Date) |
+| `GoTransit::Schedule::AllLines.all(date: <Date>)`                                                                                           | [Link](http://api.openmetrolinx.com/OpenDataAPI/Help/Api/en/GET-api-V1-Schedule-Line-All-Date) |
 | `GoTransit::Schedule::Line.stop(date: <Date>, line_code: <string>, line_direction: <string>)`                                           | [Link](http://api.openmetrolinx.com/OpenDataAPI/Help/Api/en/GET-api-V1-Schedule-Line-Stop-Date-LineCode-LineDirection) |
 | `GoTransit::Schedule.trip(date: <Date>, trip_number: <string>)`                                                                         | [Link](http://api.openmetrolinx.com/OpenDataAPI/Help/Api/en/GET-api-V1-Schedule-Trip-Date-TripNumber) |
 

--- a/spec/resources/schedule/all_lines/line_spec.rb
+++ b/spec/resources/schedule/all_lines/line_spec.rb
@@ -1,0 +1,37 @@
+RSpec.describe GoTransit::Schedule::AllLines::Line do
+  describe "#train?" do
+    context "when line is train" do
+      it "is train" do
+        line = GoTransit::Schedule::AllLines::Line.new(is_train: true)
+
+        expect(line).to be_train
+      end
+    end
+
+    context "when line is not train" do
+      it "is not train" do
+        line = GoTransit::Schedule::AllLines::Line.new(is_train: false)
+
+        expect(line).not_to be_train
+      end
+    end
+  end
+
+  describe "#bus?" do
+    context "when line is bus" do
+      it "is bus" do
+        line = GoTransit::Schedule::AllLines::Line.new(is_bus: true)
+
+        expect(line).to be_bus
+      end
+    end
+
+    context "when line is not bus" do
+      it "is not bus" do
+        line = GoTransit::Schedule::AllLines::Line.new(is_bus: false)
+
+        expect(line).not_to be_bus
+      end
+    end
+  end
+end


### PR DESCRIPTION
We could use some helper methods to make working with lines easier.

This change addresses the need by:
* Add bus? and train? helper methods to all lines