### PR TITLE
Fix Service At A Glance Train Trip Motion

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,13 +1,13 @@
 PATH
   remote: .
   specs:
-    go_transit (0.6.0)
+    go_transit (0.7.2)
       activesupport
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.0.5)
+    activesupport (7.0.8)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
@@ -25,7 +25,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.6.3)
     method_source (1.0.0)
-    minitest (5.18.0)
+    minitest (5.20.0)
     mustermann (3.0.0)
       ruby2_keywords (~> 0.0.1)
     pry (0.14.2)

--- a/lib/go_transit/resources/service_at_a_glance/trip.rb
+++ b/lib/go_transit/resources/service_at_a_glance/trip.rb
@@ -8,7 +8,7 @@ module GoTransit
                   :modified_date, :occupancy_percentage
 
     def in_motion?
-      is_in_motion.to_i.positive?
+      is_in_motion
     end
   end
 end

--- a/lib/go_transit/version.rb
+++ b/lib/go_transit/version.rb
@@ -1,3 +1,3 @@
 module GoTransit
-  VERSION = "0.7.1"
+  VERSION = "0.7.2".freeze
 end

--- a/spec/resources/service_at_a_glance/trip_spec.rb
+++ b/spec/resources/service_at_a_glance/trip_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe GoTransit::ServiceAtAGlance::Trip do
   describe "#in_motion?" do
     context "when is_stopping is 1" do
       it "is stopping" do
-        trip = GoTransit::ServiceAtAGlance::Trip.new(is_in_motion: "1")
+        trip = GoTransit::ServiceAtAGlance::Trip.new(is_in_motion: true)
 
         expect(trip).to be_in_motion
       end
@@ -10,7 +10,7 @@ RSpec.describe GoTransit::ServiceAtAGlance::Trip do
 
     context "when is_stopping is not 1" do
       it "is not stopping" do
-        trip = GoTransit::ServiceAtAGlance::Trip.new(is_in_motion: "0")
+        trip = GoTransit::ServiceAtAGlance::Trip.new(is_in_motion: false)
 
         expect(trip).not_to be_in_motion
       end


### PR DESCRIPTION
The API returns a boolean response to motion but the tests and code expected an integer. We were trying to convert integer to boolean but it was failing on real responses.

This change addresses the need by:
* Fix train trip motion to boolean instead of integer
* Bump gem version to 0.7.2