### PR TITLE
Fix Error Classes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    go_transit (0.8.0)
+    go_transit (0.8.1)
       activesupport
 
 GEM

--- a/lib/go_transit/errors.rb
+++ b/lib/go_transit/errors.rb
@@ -6,8 +6,8 @@ module GoTransit
   end
 
   NoContentError = Class.new(ApiError)
-  BadRequestError = Class.new(StandardError)
-  UnauthorizedError = Class.new(StandardError)
-  ForbiddenError = Class.new(StandardError)
-  NotFoundError = Class.new(StandardError)
+  BadRequestError = Class.new(ApiError)
+  UnauthorizedError = Class.new(ApiError)
+  ForbiddenError = Class.new(ApiError)
+  NotFoundError = Class.new(ApiError)
 end

--- a/lib/go_transit/resources/metadata.rb
+++ b/lib/go_transit/resources/metadata.rb
@@ -2,6 +2,10 @@ module GoTransit
   class Metadata < ApiResource
     attr_accessor :time_stamp, :error_code, :error_message
 
+    def to_s
+      "#{error_code} - #{error_message}"
+    end
+
     def code
       error_code.to_i
     end

--- a/lib/go_transit/version.rb
+++ b/lib/go_transit/version.rb
@@ -1,3 +1,3 @@
 module GoTransit
-  VERSION = "0.8.0".freeze
+  VERSION = "0.8.1".freeze
 end

--- a/spec/resources/metadata_spec.rb
+++ b/spec/resources/metadata_spec.rb
@@ -1,4 +1,22 @@
 RSpec.describe GoTransit::Metadata do
+  describe "#to_s" do
+    it "includes the error code" do
+      metadata = GoTransit::Metadata.new(error_code: "418")
+
+      result = metadata.to_s
+
+      expect(result).to include("418")
+    end
+
+    it "includes the error message" do
+      metadata = GoTransit::Metadata.new(error_message: "This is a test")
+
+      result = metadata.to_s
+
+      expect(result).to include("This is a test")
+    end
+  end
+
   describe "#code" do
     it "converts error_code string to an integer" do
       metadata = GoTransit::Metadata.new(error_code: "400")


### PR DESCRIPTION
Errors were getting returned as StandardError rather than an API error. It looks like the errors were not set up correctly.

This change addresses the need by:
* Fix the error classes
* Allow metadata to be converted to string