### PR TITLE
Add Option to Change API Base URL

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: .
   specs:
-    go_transit (0.8.1)
-      activesupport
+    go_transit (0.9.0)
+      activesupport (<= 7.0.8)
 
 GEM
   remote: https://rubygems.org/

--- a/go_transit.gemspec
+++ b/go_transit.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.files = Dir["lib/**/*"]
   s.require_paths = ["lib"]
 
-  s.add_dependency "activesupport"
+  s.add_dependency "activesupport", '<= 7.0.8'
 
   s.add_development_dependency "bundler"
   s.add_development_dependency "rake"

--- a/lib/go_transit.rb
+++ b/lib/go_transit.rb
@@ -62,6 +62,14 @@ module GoTransit
   @api_key = ""
 
   class << self
-    attr_accessor :api_key
+    attr_accessor :api_key, :custom_base_url
+
+    def configure
+      yield self
+    end
+
+    def base_url
+      custom_base_url || "http://api.openmetrolinx.com/OpenDataAPI/api"
+    end
   end
 end

--- a/lib/go_transit/client.rb
+++ b/lib/go_transit/client.rb
@@ -3,11 +3,11 @@ require "net/http"
 
 module GoTransit
   class Client
-    BASE_URL = "http://api.openmetrolinx.com/OpenDataAPI/api".freeze
     API_VERSION = "V1".freeze
 
     def get(path)
-      uri = URI("#{BASE_URL}/#{API_VERSION}/#{path}?key=#{GoTransit.api_key}")
+      uri = URI("#{GoTransit.base_url}/#{API_VERSION}/#{path}"\
+                "?key=#{GoTransit.api_key}")
       response = Net::HTTP.get_response(uri)
       json = JSON.parse(response.body)
       Response.new(json)

--- a/lib/go_transit/version.rb
+++ b/lib/go_transit/version.rb
@@ -1,3 +1,3 @@
 module GoTransit
-  VERSION = "0.8.1".freeze
+  VERSION = "0.9.0".freeze
 end

--- a/readme.md
+++ b/readme.md
@@ -20,7 +20,10 @@ Import go_transit and set your API key.
 
 ```ruby
 require "go_transit"
-GoTransit.api_key = "YOUR_API_KEY"
+
+GoTransit.configure do |config|
+  config.api_key = "YOUR_API_KEY"
+end
 ```
 
 This gem exposes the Go Transit API endpoints and hydrates objects related to the returned data.
@@ -80,3 +83,12 @@ At the time of development I was unable to get test data for the following endpo
 * `GET api/V1/ServiceUpdate/MarketingAlert/All` - 204 No Content
 * `GET api/V1/Fleet/Consist/All` - 403 Forbidden
 * `GET api/V1/Fleet/Consist/Engine/{EngineNumber}` - 403 Forbidden
+
+## Changing the API base url
+In some cases you may want to change the base go transit API url. You can use the `custom_base_url` config to set one:
+
+```ruby
+GoTransit.configure do |config|
+  config.custom_base_url = "https://example.com"
+end
+```

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -1,5 +1,19 @@
 RSpec.describe GoTransit::Client do
   describe "#get" do
+    it "uses a custom url if configured" do
+      GoTransit.configure do |config|
+        config.custom_base_url = "https://example.com/OpenDataAPI/api"
+      end
+      client = GoTransit::Client.new
+      allow(Net::HTTP).to receive(:get_response).and_call_original
+
+      client.get("Stop/Details/UN")
+
+      expect(Net::HTTP).to have_received(:get_response).
+        with(URI.parse("https://example.com/OpenDataAPI/api/V1/Stop/"\
+                       "Details/UN?key=")).once
+    end
+
     it "returns a response from the metrolinx API" do
       client = GoTransit::Client.new
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,5 +19,7 @@ RSpec.configure do |config|
   config.before(:each) do
     stub_request(:any, /api.openmetrolinx.com/).
       to_rack(FakeMetrolinx)
+    stub_request(:any, /example.com/).
+      to_rack(FakeMetrolinx)
   end
 end


### PR DESCRIPTION
In some cases it is beneficial to change out the base API URL. This can be used to direct traffic to a different service when required.

This change addresses the need by:
* Add custom base url
* Rework configuration