### PR TITLE
Return nil when union platform has not been announced yet

### DIFF
--- a/lib/go_transit/resources/service_update/union_departures/trip.rb
+++ b/lib/go_transit/resources/service_update/union_departures/trip.rb
@@ -4,6 +4,7 @@ module GoTransit
                   :time, :stops
 
     def platforms
+      return if platform == "-"
       platform.split("&").collect(&:strip)
     end
 

--- a/lib/go_transit/version.rb
+++ b/lib/go_transit/version.rb
@@ -1,3 +1,3 @@
 module GoTransit
-  VERSION = "0.9.0".freeze
+  VERSION = "0.10.0".freeze
 end

--- a/spec/resources/service_update/union_departures/trip_spec.rb
+++ b/spec/resources/service_update/union_departures/trip_spec.rb
@@ -7,6 +7,16 @@ RSpec.describe GoTransit::ServiceUpdate::UnionDepartures::Trip do
 
       expect(trip.platforms).to eq(["9", "10"])
     end
+
+    context "then platform has not been announced yet" do
+      it "is nil" do
+        trip = GoTransit::ServiceUpdate::UnionDepartures::Trip.new(
+          platform: "-"
+        )
+
+        expect(trip.platforms).to be_nil
+      end
+    end
   end
 
   describe "#time_utc" do


### PR DESCRIPTION
The api returns a dash instead of a blank string when union departure platforms have not yet been announced.

This change addresses the need by:
* Return nil if the platform doesnt exist yet