### PR TITLE
Fix Failing Specs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,11 +21,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.3', '2.4', '2.5', '2.6', '2.7', '3.0', '3.1', '3.2']
+        ruby-version: ['2.7', '3.0', '3.1', '3.2', '3.3', '3.4']
     env:
       CC_TEST_REPORTER_ID: ${{secrets.CC_TEST_REPORTER_ID}}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Remove gemfile.lock
       run: rm Gemfile.lock
     - name: Set up Ruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    go_transit (0.9.0)
+    go_transit (0.10.0)
       activesupport (<= 7.0.8)
 
 GEM
@@ -73,6 +73,7 @@ GEM
 PLATFORMS
   x86_64-darwin-19
   x86_64-darwin-22
+  x86_64-darwin-24
   x86_64-linux
 
 DEPENDENCIES

--- a/readme.md
+++ b/readme.md
@@ -11,6 +11,8 @@ documenation for details on available fields.
 This gem does not parse any of the GTFS feeds. For those I recommend using a
 gem dedicated to parsing GTFS Real Time feeds since it is a stardized data type.
 
+Supports Ruby 2.7.x - 3.4.x
+
 ## API Keys
 You can get a Go Transit API key here
 [http://api.openmetrolinx.com/OpenDataAPI/Help/Registration/en](http://api.openmetrolinx.com/OpenDataAPI/Help/Registration/en).

--- a/spec/support/fake_metrolinx.rb
+++ b/spec/support/fake_metrolinx.rb
@@ -1,6 +1,8 @@
 require "sinatra/base"
 
 class FakeMetrolinx < Sinatra::Base
+  set :host_authorization, permitted_hosts: []
+
   get "/OpenDataAPI/api/V1/NotFound" do
     json_response 404, "error_not_found.json"
   end


### PR DESCRIPTION
Specs are failing and it appears to have 2 root causes. 1. github
checkout has been upgraded to v4 and the v3 in use is no longer
available. 2. sinatra, used in the test suite, has an added layer of
security that needs to be disabled for tests to be successful.

This change addresses the need by:
* Update action checkout to v4
* Add bypass for allowed hosts for fake metrolinx
* Remove support for ruby < 2.7.0