### PR TITLE
Update HTTPS Endpoints

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    go_transit (0.10.0)
+    go_transit (1.0.0)
       activesupport (<= 7.0.8)
 
 GEM
@@ -15,17 +15,17 @@ GEM
     addressable (2.8.1)
       public_suffix (>= 2.0.2, < 6.0)
     coderay (1.1.3)
-    concurrent-ruby (1.2.2)
+    concurrent-ruby (1.3.5)
     crack (0.4.5)
       rexml
     diff-lcs (1.5.0)
     docile (1.4.0)
     hashdiff (1.0.1)
-    i18n (1.14.1)
+    i18n (1.14.7)
       concurrent-ruby (~> 1.0)
     json (2.6.3)
     method_source (1.0.0)
-    minitest (5.20.0)
+    minitest (5.25.5)
     mustermann (3.0.0)
       ruby2_keywords (~> 0.0.1)
     pry (0.14.2)

--- a/go_transit.gemspec
+++ b/go_transit.gemspec
@@ -5,7 +5,7 @@ require "go_transit/version"
 Gem::Specification.new do |s|
   s.name = "go_transit"
   s.version = GoTransit::VERSION
-  s.required_ruby_version = ">= 2.3.0"
+  s.required_ruby_version = ">= 2.7.0"
   s.summary = "Ruby Interface for the Go Transit API"
   s.author = "Justin Mazur"
   s.homepage = "https://github.com/jmazur/go_transit_ruby"

--- a/lib/go_transit.rb
+++ b/lib/go_transit.rb
@@ -69,7 +69,7 @@ module GoTransit
     end
 
     def base_url
-      custom_base_url || "http://api.openmetrolinx.com/OpenDataAPI/api"
+      custom_base_url || "https://api.openmetrolinx.com/OpenDataAPI/api"
     end
   end
 end

--- a/lib/go_transit/version.rb
+++ b/lib/go_transit/version.rb
@@ -1,3 +1,3 @@
 module GoTransit
-  VERSION = "0.10.0".freeze
+  VERSION = "1.0.0".freeze
 end

--- a/readme.md
+++ b/readme.md
@@ -15,7 +15,7 @@ Supports Ruby 2.7.x - 3.4.x
 
 ## API Keys
 You can get a Go Transit API key here
-[http://api.openmetrolinx.com/OpenDataAPI/Help/Registration/en](http://api.openmetrolinx.com/OpenDataAPI/Help/Registration/en).
+[https://api.openmetrolinx.com/OpenDataAPI/Help/Registration/en](https://api.openmetrolinx.com/OpenDataAPI/Help/Registration/en).
 
 ## Usage
 Import go_transit and set your API key.
@@ -33,43 +33,43 @@ This gem exposes the Go Transit API endpoints and hydrates objects related to th
 #### Stop
 | Method                                               | Reference                                                                                           |
 | :--------------------------------------------------- | :-------------------------------------------------------------------------------------------------- |
-| `GoTransit::Stop.all`                                | [Link](http://api.openmetrolinx.com/OpenDataAPI/Help/Api/en/GET-api-V1-Stop-All)                    |
-| `GoTransit::Stop.details(stop_code: <string>)`       | [Link](http://api.openmetrolinx.com/OpenDataAPI/Help/Api/en/GET-api-V1-Stop-Details-StopCode)       |
-| `GoTransit::Stop.next_service(stop_code: <string>)`  | [Link](http://api.openmetrolinx.com/OpenDataAPI/Help/Api/en/GET-api-V1-Stop-NextService-StopCode)   |
-| `GoTransit::Stop.destinations(stop_code: <string>, from_time: <string>, to_time: <string>)` | [Link](http://api.openmetrolinx.com/OpenDataAPI/Help/Api/en/GET-api-V1-Stop-Destinations-StopCode-FromTime-ToTime) |
+| `GoTransit::Stop.all`                                | [Link](https://api.openmetrolinx.com/OpenDataAPI/Help/Api/en/GET-api-V1-Stop-All)                    |
+| `GoTransit::Stop.details(stop_code: <string>)`       | [Link](https://api.openmetrolinx.com/OpenDataAPI/Help/Api/en/GET-api-V1-Stop-Details-StopCode)       |
+| `GoTransit::Stop.next_service(stop_code: <string>)`  | [Link](https://api.openmetrolinx.com/OpenDataAPI/Help/Api/en/GET-api-V1-Stop-NextService-StopCode)   |
+| `GoTransit::Stop.destinations(stop_code: <string>, from_time: <string>, to_time: <string>)` | [Link](https://api.openmetrolinx.com/OpenDataAPI/Help/Api/en/GET-api-V1-Stop-Destinations-StopCode-FromTime-ToTime) |
 
 #### Service Update
 | Method                                        | Reference                                                                                                  |
 | :-------------------------------------------- | :--------------------------------------------------------------------------------------------------------- |
-| `GoTransit::ServiceUpdate.service_alerts`     | [Link](http://api.openmetrolinx.com/OpenDataAPI/Help/Api/en/GET-api-V1-ServiceUpdate-ServiceAlert-All)     |
-| `GoTransit::ServiceUpdate.information_alerts` | [Link](http://api.openmetrolinx.com/OpenDataAPI/Help/Api/en/GET-api-V1-ServiceUpdate-InformationAlert-All) |
-| `GoTransit::ServiceUpdate.marketing_alerts`   | [Link](http://api.openmetrolinx.com/OpenDataAPI/Help/Api/en/GET-api-V1-ServiceUpdate-MarketingAlert-All)   |
-| `GoTransit::ServiceUpdate.union_departures`   | [Link](http://api.openmetrolinx.com/OpenDataAPI/Help/Api/en/GET-api-V1-ServiceUpdate-UnionDepartures-All)  |
-| `GoTransit::ServiceUpdate.service_guarantee(trip_number: <string>, operational_day: <string>)` | [Link](http://api.openmetrolinx.com/OpenDataAPI/Help/Api/en/GET-api-V1-ServiceUpdate-ServiceGuarantee-TripNumber-OperationalDay) |
-| `GoTransit::ServiceUpdate::Exceptions.train`  | [Link](http://api.openmetrolinx.com/OpenDataAPI/Help/Api/en/GET-api-V1-ServiceUpdate-Exceptions-Train)     |
-| `GoTransit::ServiceUpdate::Exceptions.bus`    | [Link](http://api.openmetrolinx.com/OpenDataAPI/Help/Api/en/GET-api-V1-ServiceUpdate-Exceptions-Bus)       |
-| `GoTransit::ServiceUpdate::Exceptions.all`    | [Link](http://api.openmetrolinx.com/OpenDataAPI/Help/Api/en/GET-api-V1-ServiceUpdate-Exceptions-All)       |
+| `GoTransit::ServiceUpdate.service_alerts`     | [Link](https://api.openmetrolinx.com/OpenDataAPI/Help/Api/en/GET-api-V1-ServiceUpdate-ServiceAlert-All)     |
+| `GoTransit::ServiceUpdate.information_alerts` | [Link](https://api.openmetrolinx.com/OpenDataAPI/Help/Api/en/GET-api-V1-ServiceUpdate-InformationAlert-All) |
+| `GoTransit::ServiceUpdate.marketing_alerts`   | [Link](https://api.openmetrolinx.com/OpenDataAPI/Help/Api/en/GET-api-V1-ServiceUpdate-MarketingAlert-All)   |
+| `GoTransit::ServiceUpdate.union_departures`   | [Link](https://api.openmetrolinx.com/OpenDataAPI/Help/Api/en/GET-api-V1-ServiceUpdate-UnionDepartures-All)  |
+| `GoTransit::ServiceUpdate.service_guarantee(trip_number: <string>, operational_day: <string>)` | [Link](https://api.openmetrolinx.com/OpenDataAPI/Help/Api/en/GET-api-V1-ServiceUpdate-ServiceGuarantee-TripNumber-OperationalDay) |
+| `GoTransit::ServiceUpdate::Exceptions.train`  | [Link](https://api.openmetrolinx.com/OpenDataAPI/Help/Api/en/GET-api-V1-ServiceUpdate-Exceptions-Train)     |
+| `GoTransit::ServiceUpdate::Exceptions.bus`    | [Link](https://api.openmetrolinx.com/OpenDataAPI/Help/Api/en/GET-api-V1-ServiceUpdate-Exceptions-Bus)       |
+| `GoTransit::ServiceUpdate::Exceptions.all`    | [Link](https://api.openmetrolinx.com/OpenDataAPI/Help/Api/en/GET-api-V1-ServiceUpdate-Exceptions-All)       |
 
 #### Service At Glance
 | Method                               | Reference                                                                                           |
 | :----------------------------------- | :-------------------------------------------------------------------------------------------------- |
-| `GoTransit::ServiceAtAGlance.buses`  | [Link](http://api.openmetrolinx.com/OpenDataAPI/Help/Api/en/GET-api-V1-ServiceataGlance-Buses-All)  |
-| `GoTransit::ServiceAtAGlance.trains` | [Link](http://api.openmetrolinx.com/OpenDataAPI/Help/Api/en/GET-api-V1-ServiceataGlance-Trains-All) |
-| `GoTransit::ServiceAtAGlance.upx`    | [Link](http://api.openmetrolinx.com/OpenDataAPI/Help/Api/en/GET-api-V1-ServiceataGlance-UPX-All)    |
+| `GoTransit::ServiceAtAGlance.buses`  | [Link](https://api.openmetrolinx.com/OpenDataAPI/Help/Api/en/GET-api-V1-ServiceataGlance-Buses-All)  |
+| `GoTransit::ServiceAtAGlance.trains` | [Link](https://api.openmetrolinx.com/OpenDataAPI/Help/Api/en/GET-api-V1-ServiceataGlance-Trains-All) |
+| `GoTransit::ServiceAtAGlance.upx`    | [Link](https://api.openmetrolinx.com/OpenDataAPI/Help/Api/en/GET-api-V1-ServiceataGlance-UPX-All)    |
 
 #### Schedule
 | Method                                                                                                                                  | Reference                     |
 | :-------------------------------------------------------------------------------------------------------------------------------------- | :---------------------------- |
-| `GoTransit::Schedule.journey(date: <Date>, from_stop_code: <string>, to_stop_code: <string>, start_time: <string>, max_journey: <int>)` | [Link](http://api.openmetrolinx.com/OpenDataAPI/Help/Api/en/GET-api-V1-Schedule-Journey-Date-FromStopCode-ToStopCode-StartTime-MaxJourney) |
-| `GoTransit::Schedule.line(date: <Date>, line_code: <string>, line_direction: <string>)`                                                 | [Link](http://api.openmetrolinx.com/OpenDataAPI/Help/Api/en/GET-api-V1-Schedule-Line-Date-LineCode-LineDirection) |
-| `GoTransit::Schedule::AllLines.all(date: <Date>)`                                                                                           | [Link](http://api.openmetrolinx.com/OpenDataAPI/Help/Api/en/GET-api-V1-Schedule-Line-All-Date) |
-| `GoTransit::Schedule::Line.stop(date: <Date>, line_code: <string>, line_direction: <string>)`                                           | [Link](http://api.openmetrolinx.com/OpenDataAPI/Help/Api/en/GET-api-V1-Schedule-Line-Stop-Date-LineCode-LineDirection) |
-| `GoTransit::Schedule.trip(date: <Date>, trip_number: <string>)`                                                                         | [Link](http://api.openmetrolinx.com/OpenDataAPI/Help/Api/en/GET-api-V1-Schedule-Trip-Date-TripNumber) |
+| `GoTransit::Schedule.journey(date: <Date>, from_stop_code: <string>, to_stop_code: <string>, start_time: <string>, max_journey: <int>)` | [Link](https://api.openmetrolinx.com/OpenDataAPI/Help/Api/en/GET-api-V1-Schedule-Journey-Date-FromStopCode-ToStopCode-StartTime-MaxJourney) |
+| `GoTransit::Schedule.line(date: <Date>, line_code: <string>, line_direction: <string>)`                                                 | [Link](https://api.openmetrolinx.com/OpenDataAPI/Help/Api/en/GET-api-V1-Schedule-Line-Date-LineCode-LineDirection) |
+| `GoTransit::Schedule::AllLines.all(date: <Date>)`                                                                                           | [Link](https://api.openmetrolinx.com/OpenDataAPI/Help/Api/en/GET-api-V1-Schedule-Line-All-Date) |
+| `GoTransit::Schedule::Line.stop(date: <Date>, line_code: <string>, line_direction: <string>)`                                           | [Link](https://api.openmetrolinx.com/OpenDataAPI/Help/Api/en/GET-api-V1-Schedule-Line-Stop-Date-LineCode-LineDirection) |
+| `GoTransit::Schedule.trip(date: <Date>, trip_number: <string>)`                                                                         | [Link](https://api.openmetrolinx.com/OpenDataAPI/Help/Api/en/GET-api-V1-Schedule-Trip-Date-TripNumber) |
 
 #### Fare
 | Method                                                                                                  | Reference                                                      |
 | :------------------------------------------------------------------------------------------------------ | :------------------------------------------------------------- |
-| `GoTransit::Fare.get(from_stop_code: <string>, to_stop_code: <string>, operational_day: <nil\|string>)` | [Link](http://api.openmetrolinx.com/OpenDataAPI/Help/Api/en/GET-api-V1-Fares-FromStopCode-ToStopCode) or [Link](http://api.openmetrolinx.com/OpenDataAPI/Help/Api/en/GET-api-V1-Fares-FromStopCode-ToStopCode-OperationalDay) |
+| `GoTransit::Fare.get(from_stop_code: <string>, to_stop_code: <string>, operational_day: <nil\|string>)` | [Link](https://api.openmetrolinx.com/OpenDataAPI/Help/Api/en/GET-api-V1-Fares-FromStopCode-ToStopCode) or [Link](https://api.openmetrolinx.com/OpenDataAPI/Help/Api/en/GET-api-V1-Fares-FromStopCode-ToStopCode-OperationalDay) |
 
 ## Dates & Times
 All dates & times returned from the GO Transit API are in the `America/Toronto`


### PR DESCRIPTION
Metrolinx now requires HTTPS for each endpoint. Awesome.

This change addresses the need by:
* Update client endpoint to https
* Update docs to HTTPS links
* Update missing ruby requirement in gemspec
* Bump version to 1.0.0