### PR TITLE
Fix Date Parsing for Scheduled Trip Endpoint

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    go_transit (1.0.1)
+    go_transit (1.0.2)
       activesupport
 
 GEM

--- a/lib/go_transit/resources/schedule.rb
+++ b/lib/go_transit/resources/schedule.rb
@@ -2,12 +2,12 @@ module GoTransit
   class Schedule < ApiResource
     attr_accessor :lines, :trips
 
-    def self.journey(date:, from_stop_code:, to_stop_code:, start_time:, 
+    def self.journey(date:, from_stop_code:, to_stop_code:, start_time:,
                      max_journey:)
       formatted_date = date.strftime("%Y%m%d")
       client = Client.new
       response = client.get(
-        "Schedule/Journey/#{formatted_date}/#{from_stop_code}/" + 
+        "Schedule/Journey/#{formatted_date}/#{from_stop_code}/" \
         "#{to_stop_code}/#{start_time}/#{max_journey}"
       )
       Schedule::Journey.new(response.data)
@@ -23,8 +23,9 @@ module GoTransit
     end
 
     def self.trip(date:, trip_number:)
+      formatted_date = date.strftime("%Y%m%d")
       client = Client.new
-      response = client.get("Schedule/Trip/#{date}/#{trip_number}")
+      response = client.get("Schedule/Trip/#{formatted_date}/#{trip_number}")
       new(response.data).trips
     end
   end

--- a/lib/go_transit/version.rb
+++ b/lib/go_transit/version.rb
@@ -1,3 +1,3 @@
 module GoTransit
-  VERSION = "1.0.1".freeze
+  VERSION = "1.0.2".freeze
 end


### PR DESCRIPTION
I found that the scheduled trip endpoint was not working with date object and not formatting them correctly. It needs to be adjusted to match the other endpoints.

This change addresses the need by:
* Add date formatting to scheduled trip endpoint
* Bump version